### PR TITLE
feat: Displays invoice_items on show page

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -1,5 +1,5 @@
 class InvoicesController < ApplicationController
   def index
-    
+
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -10,8 +10,5 @@ class Invoice < ApplicationRecord
    def self.incomplete_invoices
       joins(:invoice_items).where(invoice_items: {status: ["pending", "packaged"]}).distinct.order(created_at: :asc)
    end
-
-
-
 end
 

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -2,3 +2,13 @@
 <h3>Status: <%= "#{@invoice.status}"%>
 <h3>Created on: <%= "#{@invoice.created_at.strftime("%A, %B %d, %Y")}"%>
 <h3>Customer Name: <%= "#{@invoice.customer.first_name} #{@invoice.customer.last_name}"%>
+
+<h2>Items:</h2>
+	<% @merchant.invoice_items.each do |invoice_item| %> 
+	<div id=<%="invoice_item-#{invoice_item.id}"%>> 
+		<h3>ID: <%= invoice_item.item.name %> </h3>
+		<p>Quantity: <%= invoice_item.quantity %> </p>
+		<p>Unit Price: $<%= invoice_item.converted_unit_price %> </p>
+		<p>Status: <%= invoice_item.status %> 
+
+		</div> <% end %>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Merchant_invoices Show Page', type: :feature do
   describe 'merch_invoices show' do
+    # User Story 15
     it 'displays invoice id, status, created_at, customer name to show page' do
       @green_merchant = Merchant.create!(name: "Green Inc")
 
@@ -16,18 +17,58 @@ RSpec.describe 'Merchant_invoices Show Page', type: :feature do
       @invoice_item_1 = InvoiceItem.create!(item_id: @item1.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 1000, status: "shipped") #5000
       @invoice_item_3 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice1.id, quantity: 2, unit_price: 1000, status: "shipped") #2000
       @invoice_item_4 = InvoiceItem.create!(item_id: @item3.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 1000, status: "packaged") #5000
-#       When I visit my merchant's invoice show page (/merchants/:merchant_id/invoices/:invoice_id)
+
     visit merchant_invoice_path(@green_merchant, @invoice1)
-        expect(page).to have_content("Invoice #{@invoice1.id}")
-        expect(page).to have_content("Status: completed")
-        expect(page).to have_content("Created on: Wednesday, February 28, 2024") #"Created on: Wednesday, February 28, 2024"        #{@invoice1.created_at.strftime("%A, %B %d, %Y")}
-        expect(page).to have_content("Joey Ondricka")
-        save_and_open_page
+      expect(page).to have_content("Invoice #{@invoice1.id}")
+      expect(page).to have_content("Status: completed")
+      expect(page).to have_content("Created on: Wednesday, February 28, 2024") 
+      expect(page).to have_content("Joey Ondricka")
+    end
+    
+    # User Story 16
+    it "lists all items on the invoice" do
+      @green_merchant = Merchant.create!(name: "Green Inc")
+      @black_merchant = Merchant.create!(name: "Black Inc")
+      
+      @item1 = Item.create!(name: "table", description: "it's a table", unit_price: 2546, merchant_id: @green_merchant.id)
+      @item2 = Item.create!(name: "pen", description: "it's a pen", unit_price: 5367, merchant_id: @green_merchant.id)
+      @item3 = Item.create!(name: "paper", description: "it's paper", unit_price: 8767, merchant_id: @green_merchant.id)
+      @item4 = Item.create!(name: "paper", description: "it's paper", unit_price: 8767, merchant_id: @black_merchant.id)
+      
+      @cust_1 = Customer.create!(first_name: "Joey", last_name: "Ondricka")
+      
+      @invoice1 = Invoice.create!(customer_id: @cust_1.id, status: 1)
+      
+      @invoice_item_1 = InvoiceItem.create!(item_id: @item1.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 2546, status: "shipped") #5000
+      @invoice_item_3 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice1.id, quantity: 2, unit_price: 5367, status: "shipped") #2000
+      @invoice_item_4 = InvoiceItem.create!(item_id: @item3.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 8767, status: "packaged") #5000
+      @invoice_item_5 = InvoiceItem.create!(item_id: @item4.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 8767, status: "packaged") #5000
+      
+      visit merchant_invoice_path(@green_merchant, @invoice1)
+      
+      within"#invoice_item-#{@invoice_item_1.id}" do
+        expect(page).to have_content(@invoice_item_1.item.name)
+        expect(page).to have_content(@invoice_item_1.quantity)
+        expect(page).to have_content("Unit Price: $#{@invoice_item_1.converted_unit_price}")
+        expect(page).to have_content(@invoice_item_1.status)
+      end
+      
+      within"#invoice_item-#{@invoice_item_3.id}" do
+        expect(page).to have_content(@invoice_item_3.item.name)
+        expect(page).to have_content(@invoice_item_3.quantity)
+        expect(page).to have_content("Unit Price: $#{@invoice_item_3.converted_unit_price}")
+        expect(page).to have_content(@invoice_item_3.status)
+      end
+
+      within"#invoice_item-#{@invoice_item_4.id}" do
+        expect(page).to have_content(@invoice_item_4.item.name)
+        expect(page).to have_content(@invoice_item_4.quantity)
+        expect(page).to have_content("Unit Price: $#{@invoice_item_4.converted_unit_price}")
+        expect(page).to have_content(@invoice_item_4.status)
+      end
+
+      expect(page).not_to have_content(@invoice_item_5.id)
+
     end
   end
 end
-# Then I see information related to that invoice including:
-# - Invoice id
-# - Invoice status
-# - Invoice created_at date in the format "Monday, July 18, 2019"
-# - Customer first and last name


### PR DESCRIPTION
This will display the following on the merchant_invoice show page:
- Item name
- The quantity of the item ordered
- The price the Item sold for
- The Invoice Item status
Tested to make sure it will not display information related to Items for other merchants