### PR TITLE
Merch show total rev

### DIFF
--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -11,6 +11,6 @@ class InvoiceItem < ApplicationRecord
    def total_revenue
       total_rev = (unit_price.to_f/100) * quantity
       formatted_tot_rev = '%.2f' % total_rev
-      formatted_tot_rev
+      formatted_tot_rev.to_f
    end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -9,6 +9,8 @@ class InvoiceItem < ApplicationRecord
    end
 
    def total_revenue
-      (unit_price.to_f/100) * quantity
+      total_rev = (unit_price.to_f/100) * quantity
+      formatted_tot_rev = '%.2f' % total_rev
+      formatted_tot_rev
    end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -28,7 +28,7 @@
             <p>Status: <%= invoice_item.status.capitalize %></p>
             <p> - </p>
          </li>
-      <h4>Total Revenue: $<%= invoice_item.total_revenue.round(2) %></h4>
+      <h4>Total Revenue: <%= invoice_item.total_revenue %></h4>
       </div>
    <% end %>
    </ul>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -3,12 +3,17 @@
 <h3>Created on: <%= "#{@invoice.created_at.strftime("%A, %B %d, %Y")}"%>
 <h3>Customer Name: <%= "#{@invoice.customer.first_name} #{@invoice.customer.last_name}"%>
 
-<h2>Items:</h2>
-	<% @merchant.invoice_items.each do |invoice_item| %> 
+<h2>Items: </h2>
+<ul>
+<% @merchant.invoice_items.each do |invoice_item| %> 
 	<div id=<%="invoice_item-#{invoice_item.id}"%>> 
-		<h3>ID: <%= invoice_item.item.name %> </h3>
-		<p>Quantity: <%= invoice_item.quantity %> </p>
-		<p>Unit Price: $<%= invoice_item.converted_unit_price %> </p>
-		<p>Status: <%= invoice_item.status %> 
-
-		</div> <% end %>
+		<li>
+			<h4>Item: <%= invoice_item.item.name %> </h4>
+			<p>Quantity: <%= invoice_item.quantity %> </p>
+			<p>Unit Price: $<%= invoice_item.converted_unit_price %> </p>
+			<p>Status: <%= invoice_item.status %> 
+		</li>
+	<h4>Total Revenue: <%= invoice_item.total_revenue %></h4>
+			</div> 
+<% end %>
+<ul>

--- a/doc/user_stories.md
+++ b/doc/user_stories.md
@@ -1,4 +1,4 @@
-# User Stories
+    # User Stories
 
 These user stories will require you to build many pages. This repo includes wireframes for the following pages:
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -1,24 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe 'Merchant_invoices Show Page', type: :feature do
+  before do 
+    @green_merchant = Merchant.create!(name: "Green Inc")
+    @black_merchant = Merchant.create!(name: "Black Inc")
+    
+    @item1 = Item.create!(name: "table", description: "it's a table", unit_price: 2546, merchant_id: @green_merchant.id)
+    @item2 = Item.create!(name: "pen", description: "it's a pen", unit_price: 5367, merchant_id: @green_merchant.id)
+    @item3 = Item.create!(name: "paper", description: "it's paper", unit_price: 8767, merchant_id: @green_merchant.id)
+    @item4 = Item.create!(name: "paper", description: "it's paper", unit_price: 8767, merchant_id: @black_merchant.id)
+    
+    @cust_1 = Customer.create!(first_name: "Joey", last_name: "Ondricka")
+    
+    @invoice1 = Invoice.create!(customer_id: @cust_1.id, status: 1)
+    
+    @invoice_item_1 = InvoiceItem.create!(item_id: @item1.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 2546, status: "shipped") #5000
+    @invoice_item_3 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice1.id, quantity: 2, unit_price: 5367, status: "shipped") #2000
+    @invoice_item_4 = InvoiceItem.create!(item_id: @item3.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 8767, status: "packaged") #5000
+    @invoice_item_5 = InvoiceItem.create!(item_id: @item4.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 8767, status: "packaged") #5000|
+  end
+
   describe 'merch_invoices show' do
     # User Story 15
     it 'displays invoice id, status, created_at, customer name to show page' do
-      @green_merchant = Merchant.create!(name: "Green Inc")
+      visit merchant_invoice_path(@green_merchant, @invoice1)
 
-      @item1 = Item.create!(name: "table", description: "it's a table", unit_price: 2546, merchant_id: @green_merchant.id)
-      @item2 = Item.create!(name: "pen", description: "it's a pen", unit_price: 5367, merchant_id: @green_merchant.id)
-      @item3 = Item.create!(name: "paper", description: "it's paper", unit_price: 8767, merchant_id: @green_merchant.id)
-
-      @cust_1 = Customer.create!(first_name: "Joey", last_name: "Ondricka")
-
-      @invoice1 = Invoice.create!(customer_id: @cust_1.id, status: 1)
-
-      @invoice_item_1 = InvoiceItem.create!(item_id: @item1.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 1000, status: "shipped") #5000
-      @invoice_item_3 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice1.id, quantity: 2, unit_price: 1000, status: "shipped") #2000
-      @invoice_item_4 = InvoiceItem.create!(item_id: @item3.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 1000, status: "packaged") #5000
-
-    visit merchant_invoice_path(@green_merchant, @invoice1)
       expect(page).to have_content("Invoice #{@invoice1.id}")
       expect(page).to have_content("Status: completed")
       expect(page).to have_content("Created on: Wednesday, February 28, 2024") 
@@ -27,23 +33,6 @@ RSpec.describe 'Merchant_invoices Show Page', type: :feature do
     
     # User Story 16
     it "lists all items on the invoice" do
-      @green_merchant = Merchant.create!(name: "Green Inc")
-      @black_merchant = Merchant.create!(name: "Black Inc")
-      
-      @item1 = Item.create!(name: "table", description: "it's a table", unit_price: 2546, merchant_id: @green_merchant.id)
-      @item2 = Item.create!(name: "pen", description: "it's a pen", unit_price: 5367, merchant_id: @green_merchant.id)
-      @item3 = Item.create!(name: "paper", description: "it's paper", unit_price: 8767, merchant_id: @green_merchant.id)
-      @item4 = Item.create!(name: "paper", description: "it's paper", unit_price: 8767, merchant_id: @black_merchant.id)
-      
-      @cust_1 = Customer.create!(first_name: "Joey", last_name: "Ondricka")
-      
-      @invoice1 = Invoice.create!(customer_id: @cust_1.id, status: 1)
-      
-      @invoice_item_1 = InvoiceItem.create!(item_id: @item1.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 2546, status: "shipped") #5000
-      @invoice_item_3 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice1.id, quantity: 2, unit_price: 5367, status: "shipped") #2000
-      @invoice_item_4 = InvoiceItem.create!(item_id: @item3.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 8767, status: "packaged") #5000
-      @invoice_item_5 = InvoiceItem.create!(item_id: @item4.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 8767, status: "packaged") #5000
-      
       visit merchant_invoice_path(@green_merchant, @invoice1)
       
       within"#invoice_item-#{@invoice_item_1.id}" do
@@ -68,7 +57,12 @@ RSpec.describe 'Merchant_invoices Show Page', type: :feature do
       end
 
       expect(page).not_to have_content(@invoice_item_5.id)
+    end
 
+    # User Story 16
+    it "Displays total revenue from all items on invoice" do
+      visit merchant_invoice_path(@green_merchant, @invoice1)
+      expect(page).to have_content(@invoice_item_1.total_revenue)
     end
   end
 end

--- a/spec/models/invoice_items_spec.rb
+++ b/spec/models/invoice_items_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe InvoiceItem, type: :model do
    describe '#total_revenue' do
       it 'calculated the revenue for a invoice item' do
          invoice_item = create(:invoice_item, unit_price: 40000, quantity: 5)
-
          expect(invoice_item.total_revenue).to eq(2000.00)
 
       end


### PR DESCRIPTION
Adds Total revenue to merchant invoice show page by utilizing pre-existing #total_revenue

I did update the method because my RV was 127.0000000 and it only returned 127.0.  I had to pad the right of the decimal with updated code: 

  def total_revenue
      total_rev = (unit_price.to_f/100) * quantity
      formatted_tot_rev = '%.2f' % total_rev
      formatted_tot_rev.to_f
   end

Updated other files to work with new code